### PR TITLE
[Feature] Svg Aria-Label Template Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ This is a collection of custom [`ember-template-lint`](https://github.com/ember-
 
 The following sets of rules are available for your `ember-template-lint` configuration to extend from:
 
-| Name                        | Description                                                          |
-| :-------------------------- | :------------------------------------------------------------------- |
-| `avoid-possible-typos`      | Rules meant to catch possible typos in your templates                |
-| `avoid-deprecated-elements` | Rules meant to catch `<b>` and `<i>` tags, use `<strong>` and `<em>` |
-| `base`                      | The base set of rules used across all Movable Ink projects           |
+| Name                        | Description                                                            |
+| :-------------------------- | :--------------------------------------------------------------------- |
+| `avoid-possible-typos`      | Rules meant to catch possible typos in your templates                  |
+| `avoid-deprecated-elements` | Rules meant to catch `<b>` and `<i>` tags, use `<strong>` and `<em>`   |
+| `svg-aria-required`         | Rules meant to catch svgs without an `aria-label` or `aria-labelledby` |
+| `base`                      | The base set of rules used across all Movable Ink projects             |
 
 ## Usage
 
@@ -42,6 +43,7 @@ module.exports = {
     // You can extend a whole set of rules
     '@movable/template-lint-plugin:avoid-possible-typos',
     '@movable/template-lint-plugin:avoid-deprecated-elements',
+    '@movable/template-lint-plugin:svg-aria-required',
   ],
 
   rules: [

--- a/lib/rules/svg-aria-required.js
+++ b/lib/rules/svg-aria-required.js
@@ -1,0 +1,19 @@
+const { Rule } = require('ember-template-lint');
+
+const ERROR_MESSAGE = 'an svg must have either an aria-label or aria-labelledby attribute';
+
+module.exports = class SvgAriaRequired extends Rule {
+  visitor() {
+    return {
+      MustacheStatement(node) {
+        if (
+          node.path.original === 'svg-jar' &&
+          !node.hash.pairs.some((p) => ['aria-label', 'aria-labelledby'].includes(p.key))
+        )
+          this.log({ message: ERROR_MESSAGE, node });
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/tests/lib/rules/svg-aria-required-test.js
+++ b/tests/lib/rules/svg-aria-required-test.js
@@ -1,0 +1,24 @@
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const { ERROR_MESSAGE } = require('../../../lib/rules/svg-aria-required');
+
+generateRuleTests({
+  name: 'svg-aria-required',
+  config: true,
+  groupMethodBefore: beforeEach,
+  groupingMethod: describe,
+  testMethod: test,
+
+  good: [`{{svg-jar "hello" aria-label="yeah"}}`, `{{svg-jar "hello" aria-labelledby="yeah"}}`],
+
+  bad: [
+    {
+      template: `{{svg-jar "hello" data-test="yeah"}}`,
+      result: {
+        message: ERROR_MESSAGE,
+        column: 0,
+        line: 1,
+        source: '{{svg-jar "hello" data-test="yeah"}}',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
### Current Behavior
Users can use svg's without `aria-labels`

Users are experiencing a double tool-tip experience caused by `title` tags in svgs. By forcing the use of `aria-labels` we can maintain accessibility with screen readers. 

### Why do we need this change?
Code cleanup

### Implementation Details
Proof of concept PR here: https://github.com/movableink/front-end/pull/7528

[:tickets: [sc-68292]](https://app.shortcut.com/movableink/story/68292)
